### PR TITLE
Bump zkverify version to 0.4.0

### DIFF
--- a/docs/tutorials/05-how_to_run_a_node/02-run_using_docker/01-getting_started_docker.md
+++ b/docs/tutorials/05-how_to_run_a_node/02-run_using_docker/01-getting_started_docker.md
@@ -56,13 +56,13 @@ brew install gsed
 Finally, clone the repository [compose-zkverify-simplified](https://github.com/HorizenLabs/compose-zkverify-simplified) with the command:
 
 ```bash
-git clone --branch 0.3.0 https://github.com/HorizenLabs/compose-zkverify-simplified.git
+git clone --branch 0.4.0 https://github.com/HorizenLabs/compose-zkverify-simplified.git
 ```
 
-Or directly download the [archive](https://github.com/HorizenLabs/compose-zkverify-simplified/archive/refs/tags/0.3.0.zip) and unzip it.
+Or directly download the [archive](https://github.com/HorizenLabs/compose-zkverify-simplified/archive/refs/tags/0.4.0.zip) and unzip it.
 
 :::tip[**Recommendation: use the latest tag**]
-It is recommended that you use the latest tag in order to run the latest and most updated software. Check the [releases page](https://github.com/HorizenLabs/compose-zkverify-simplified/releases) to find the latest tag and if needed update it accordingly via the command or link provided above (here tag `0.3.0` is used).
+It is recommended that you use the latest tag in order to run the latest and most updated software. Check the [releases page](https://github.com/HorizenLabs/compose-zkverify-simplified/releases) to find the latest tag and if needed update it accordingly via the command or link provided above (here tag `0.4.0` is used).
 :::
 
 This repository contains several resources to help you in the preparation of the environment for running your node.

--- a/docs/tutorials/05-how_to_run_a_node/02-run_using_docker/05-update_running_node.md
+++ b/docs/tutorials/05-how_to_run_a_node/02-run_using_docker/05-update_running_node.md
@@ -8,11 +8,11 @@ To update an already running node (wheter it is an RPC node, boot node or valida
 
 ```bash
 cd compose-zkverify-simplified
-git checkout 0.3.0
+git checkout 0.4.0
 ```
 
 :::tip[**Recommendation: use the latest tag**]
-It is recommended to use the latest tag in order to run the latest, most updated software.  Check the [releases page](https://github.com/HorizenLabs/compose-zkverify-simplified/releases) to find the latest tag and if needed, update accordingly the command provided above (here tag `0.3.0` is used).
+It is recommended to use the latest tag in order to run the latest, most updated software.  Check the [releases page](https://github.com/HorizenLabs/compose-zkverify-simplified/releases) to find the latest tag and if needed, update accordingly the command provided above (here tag `0.4.0` is used).
 :::
 
 Then launch the update script by typing:

--- a/docs/tutorials/05-how_to_run_a_node/03-run_using_binaries/01-getting_started_binaries.md
+++ b/docs/tutorials/05-how_to_run_a_node/03-run_using_binaries/01-getting_started_binaries.md
@@ -17,11 +17,11 @@ Below is a list of prerequisites that need to be available on your machine in or
 Lastly, clone the repository [zkVerify](https://github.com/HorizenLabs/zkVerify) with the command:
 
 ```bash
-git clone --branch 0.3.0 https://github.com/HorizenLabs/zkVerify.git
+git clone --branch 0.4.0 https://github.com/HorizenLabs/zkVerify.git
 ```
 
 :::tip[**Recommendation: use the latest tag**]
-It is recommended that you use the latest tag in order to run the latest and most updated software. Check the [releases page](https://github.com/HorizenLabs/compose-zkverify-simplified/releases) to find the latest tag and if needed update it accordingly via the command or link provided above (here tag `0.3.0` is used). You can also target directly `main` branch using `git clone --branch 0.3.0 https://github.com/HorizenLabs/zkVerify.git` but ensure that you fully understand the implications of doing so.
+It is recommended that you use the latest tag in order to run the latest and most updated software. Check the [tags page](https://github.com/HorizenLabs/zkVerify/tags) to find the latest tag and if needed update it accordingly via the command or link provided above (here tag `0.4.0` is used). You can also target directly `main` branch using `git clone https://github.com/HorizenLabs/zkVerify.git` but ensure that you fully understand the implications of doing so.
 :::
 
 This repository contains the implementation of a **zkVerify** node. It is based on the [Substrate](https://substrate.io/) framework.

--- a/docs/tutorials/05-how_to_run_a_node/03-run_using_binaries/05-update_running_node.md
+++ b/docs/tutorials/05-how_to_run_a_node/03-run_using_binaries/05-update_running_node.md
@@ -8,11 +8,11 @@ To update an already running node (wheter it is an RPC node, boot node or valida
 
 ```bash
 cd zkVerify
-git checkout 0.3.0
+git checkout 0.4.0
 ```
 
 :::tip[**Recommendation: use the latest tag**]
-It is recommended to use the latest tag in order to run the latest, most updated software. Check the [releases page](https://github.com/HorizenLabs/compose-zkverify-simplified/releases) to find the latest tag and if needed, update accordingly the command provided above (here tag `0.3.0` is used).
+It is recommended to use the latest tag in order to run the latest, most updated software. Check the [releases page](https://github.com/HorizenLabs/compose-zkverify-simplified/releases) to find the latest tag and if needed, update accordingly the command provided above (here tag `0.4.0` is used).
 :::
 
 After checking out the new source code version, build it with:

--- a/versioned_docs/version-1.0.0/tutorials/05-how_to_run_a_node/02-run_using_docker/01-getting_started_docker.md
+++ b/versioned_docs/version-1.0.0/tutorials/05-how_to_run_a_node/02-run_using_docker/01-getting_started_docker.md
@@ -56,13 +56,13 @@ brew install gsed
 Finally, clone the repository [compose-zkverify-simplified](https://github.com/HorizenLabs/compose-zkverify-simplified) with the command:
 
 ```bash
-git clone --branch 0.3.0 https://github.com/HorizenLabs/compose-zkverify-simplified.git
+git clone --branch 0.4.0 https://github.com/HorizenLabs/compose-zkverify-simplified.git
 ```
 
-Or directly download the [archive](https://github.com/HorizenLabs/compose-zkverify-simplified/archive/refs/tags/0.3.0.zip) and unzip it.
+Or directly download the [archive](https://github.com/HorizenLabs/compose-zkverify-simplified/archive/refs/tags/0.4.0.zip) and unzip it.
 
 :::tip[**Recommendation: use the latest tag**]
-It is recommended that you use the latest tag in order to run the latest and most updated software. Check the [releases page](https://github.com/HorizenLabs/compose-zkverify-simplified/releases) to find the latest tag and if needed update it accordingly via the command or link provided above (here tag `0.3.0` is used).
+It is recommended that you use the latest tag in order to run the latest and most updated software. Check the [releases page](https://github.com/HorizenLabs/compose-zkverify-simplified/releases) to find the latest tag and if needed update it accordingly via the command or link provided above (here tag `0.4.0` is used).
 :::
 
 This repository contains several resources to help you in the preparation of the environment for running your node.

--- a/versioned_docs/version-1.0.0/tutorials/05-how_to_run_a_node/02-run_using_docker/05-update_running_node.md
+++ b/versioned_docs/version-1.0.0/tutorials/05-how_to_run_a_node/02-run_using_docker/05-update_running_node.md
@@ -8,11 +8,11 @@ To update an already running node (wheter it is an RPC node, boot node or valida
 
 ```bash
 cd compose-zkverify-simplified
-git checkout 0.3.0
+git checkout 0.4.0
 ```
 
 :::tip[**Recommendation: use the latest tag**]
-It is recommended to use the latest tag in order to run the latest, most updated software.  Check the [releases page](https://github.com/HorizenLabs/compose-zkverify-simplified/releases) to find the latest tag and if needed, update accordingly the command provided above (here tag `0.3.0` is used).
+It is recommended to use the latest tag in order to run the latest, most updated software.  Check the [releases page](https://github.com/HorizenLabs/compose-zkverify-simplified/releases) to find the latest tag and if needed, update accordingly the command provided above (here tag `0.4.0` is used).
 :::
 
 Then launch the update script by typing:

--- a/versioned_docs/version-1.0.0/tutorials/05-how_to_run_a_node/03-run_using_binaries/01-getting_started_binaries.md
+++ b/versioned_docs/version-1.0.0/tutorials/05-how_to_run_a_node/03-run_using_binaries/01-getting_started_binaries.md
@@ -17,11 +17,11 @@ Below is a list of prerequisites that need to be available on your machine in or
 Lastly, clone the repository [zkVerify](https://github.com/HorizenLabs/zkVerify) with the command:
 
 ```bash
-git clone --branch 0.3.0 https://github.com/HorizenLabs/zkVerify.git
+git clone --branch 0.4.0 https://github.com/HorizenLabs/zkVerify.git
 ```
 
 :::tip[**Recommendation: use the latest tag**]
-It is recommended that you use the latest tag in order to run the latest and most updated software. Check the [releases page](https://github.com/HorizenLabs/compose-zkverify-simplified/releases) to find the latest tag and if needed update it accordingly via the command or link provided above (here tag `0.3.0` is used). You can also target directly `main` branch using `git clone --branch 0.3.0 https://github.com/HorizenLabs/zkVerify.git` but ensure that you fully understand the implications of doing so.
+It is recommended that you use the latest tag in order to run the latest and most updated software. Check the [tags page](https://github.com/HorizenLabs/zkVerify/tags) to find the latest tag and if needed update it accordingly via the command or link provided above (here tag `0.4.0` is used). You can also target directly `main` branch using `git clone https://github.com/HorizenLabs/zkVerify.git` but ensure that you fully understand the implications of doing so.
 :::
 
 This repository contains the implementation of a **zkVerify** node. It is based on the [Substrate](https://substrate.io/) framework.

--- a/versioned_docs/version-1.0.0/tutorials/05-how_to_run_a_node/03-run_using_binaries/05-update_running_node.md
+++ b/versioned_docs/version-1.0.0/tutorials/05-how_to_run_a_node/03-run_using_binaries/05-update_running_node.md
@@ -8,11 +8,11 @@ To update an already running node (wheter it is an RPC node, boot node or valida
 
 ```bash
 cd zkVerify
-git checkout 0.3.0
+git checkout 0.4.0
 ```
 
 :::tip[**Recommendation: use the latest tag**]
-It is recommended to use the latest tag in order to run the latest, most updated software. Check the [releases page](https://github.com/HorizenLabs/compose-zkverify-simplified/releases) to find the latest tag and if needed, update accordingly the command provided above (here tag `0.3.0` is used).
+It is recommended to use the latest tag in order to run the latest, most updated software. Check the [releases page](https://github.com/HorizenLabs/compose-zkverify-simplified/releases) to find the latest tag and if needed, update accordingly the command provided above (here tag `0.4.0` is used).
 :::
 
 After checking out the new source code version, build it with:


### PR DESCRIPTION
Manually bumping to `0.4.0` version for `zkVerify` and `compose-zkverify-simplified` repos.