### PR TITLE
Removed outdated disclaimer

### DIFF
--- a/docs/tutorials/06-how_to_run_a_node/03-run_using_binaries/01-getting_started_binaries.md
+++ b/docs/tutorials/06-how_to_run_a_node/03-run_using_binaries/01-getting_started_binaries.md
@@ -39,21 +39,6 @@ We are working towards removing this dependency in the upcoming future.
 To build the source code, open a terminal at `root` and type:
 
 ```bash
-cargo build --profile production
-```
-
-or:
-
-```bash
-cargo build
-```
-
-For a debug build.
-
-:::warning
-If you are compiling from the `main` branch, use instead:
-
-```bash
 cargo build -p mainchain --profile production
 ```
 
@@ -64,8 +49,6 @@ cargo build -p mainchain
 ```
 
 For a debug build.
-
-:::
 
 The build process downloads all the dependencies and can take several minutes on the first run.  When finished, you can find the build output in directory `target/production` (or `target/debug`).  The node executable is `zkv-node`.
 

--- a/docs/tutorials/06-how_to_run_a_node/03-run_using_binaries/05-update_running_node.md
+++ b/docs/tutorials/06-how_to_run_a_node/03-run_using_binaries/05-update_running_node.md
@@ -20,7 +20,7 @@ It is recommended to use the latest tag in order to run the latest, most updated
 After checking out the new source code version, build it with:
 
 ```bash
-cargo build --profile production
+cargo build -p mainchain --profile production
 ```
 
 After the building process has finished, stop your currently running node by pressing `ctrl+c` in the associated terminal and restart it with `target/production/zkv-node` using the same command-line arguments you previously used to start your node.


### PR DESCRIPTION
Now latest tag 0.7.0-0.9.0 contains the relay chain as well, so no need to keep this disclaimer